### PR TITLE
Rename parseRPCResponse to parseAnyRPCResponse

### DIFF
--- a/docs/build/quick-start/index.md
+++ b/docs/build/quick-start/index.md
@@ -76,7 +76,7 @@ Create a file `app.js` and connect to the Yellow Network.
 :::
 
 ```javascript title="app.js" showLineNumbers
-import { createAppSessionMessage, parseRPCResponse } from '@erc7824/nitrolite';
+import { createAppSessionMessage, parseAnyRPCResponse } from '@erc7824/nitrolite';
 
 // Connect to Yellow Network (using sandbox for testing)
 const ws = new WebSocket('wss://clearnet-sandbox.yellow.com/ws');


### PR DESCRIPTION
parseRPCResponse doesn't exist or may have been deprecated