### PR TITLE
docs: fix codemod callout wording and add setup steps

### DIFF
--- a/docs/build/sdk/typescript-compat/migration-overview.mdx
+++ b/docs/build/sdk/typescript-compat/migration-overview.mdx
@@ -13,7 +13,7 @@ This guide explains how to migrate your Nitrolite dApp from the v0.5.3 SDK to th
 A direct migration from v0.5.3 to v1.0.0 touches **20+ files** per app with deep, scattered rewrites. The compat layer reduces this to **~5 file changes** per app.
 
 :::tip Automate with Codemod
-Before migrating manually, try the [yellow-sdk-codemod](https://github.com/layer-3/yellow-sdk-codemod). It rewrites imports, renames auth fields, migrates client constructors, updates `package.json`, and flags RPC patterns with `// TODO [codemod]` comments for the remaining manual steps.
+Before migrating manually, try the [yellow-sdk-codemod](https://github.com/layer-3/yellow-sdk-codemod). It rewrites `@erc7824/nitrolite` imports, renames auth fields, migrates client constructors, updates `package.json`, and flags RPC patterns with `// TODO [codemod]` comments for the remaining manual steps.
 :::
 
 ## Installation

--- a/docs/build/sdk/typescript-compat/overview.mdx
+++ b/docs/build/sdk/typescript-compat/overview.mdx
@@ -9,9 +9,9 @@ sidebar_position: 1
 Compatibility layer that bridges the Nitrolite SDK **v0.5.3 API** to the **v1.0.0 runtime**, letting existing dApps upgrade to the new protocol with minimal code changes.
 
 <details>
-<summary><strong>Already integrated with <code>@erc7824/nitrolite</code> or <code>@layer-3/nitrolite</code>?</strong></summary>
+<summary><strong>Already integrated with <code>@erc7824/nitrolite</code>?</strong></summary>
 
-If your app is already built on `@erc7824/nitrolite` (v0.4 through v0.5.3) or `@layer-3/nitrolite`, you can speed up the migration using the [yellow-sdk-codemod](https://github.com/layer-3/yellow-sdk-codemod) tool. It handles the repetitive parts of the upgrade automatically: rewriting imports, migrating client constructors, renaming auth fields, and updating your `package.json`. Where the change requires context (collapsing RPC call chains, removing manual WebSocket setup), the codemod leaves a `// TODO [codemod]` comment with the exact replacement so you know what to do.
+If your app is already built on `@erc7824/nitrolite` (v0.4 through v0.5.3), you can speed up the migration using the [yellow-sdk-codemod](https://github.com/layer-3/yellow-sdk-codemod) tool. It handles the repetitive parts of the upgrade automatically: rewriting imports, migrating client constructors, renaming auth fields, and updating your `package.json`. Where the change requires context (collapsing RPC call chains, removing manual WebSocket setup), the codemod leaves a `// TODO [codemod]` comment with the exact replacement so you know what to do.
 
 ```bash
 # Clone the codemod and install its dependencies


### PR DESCRIPTION
## Summary

- Remove incorrect `@layer-3/nitrolite` references from codemod callouts (that package was never published; old SDK was only `@erc7824/nitrolite`)
- Add explicit clone + install steps to the overview collapsible so the CLI commands have proper context

Follows up on #127.

## Test plan

- [ ] Verify both `.mdx` pages render correctly in Docusaurus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript migration guides to clarify codemod compatibility and specify import rewrite details. Added installation instructions for codemod dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->