### PR TITLE
chore: add Claude Code config for docs site

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -1,0 +1,12 @@
+---
+globs: ["docs/**/*.md", "docs/**/*.mdx", "blog/**/*.md"]
+---
+
+- Use MDX for pages needing interactive components; plain Markdown for simple content.
+- Always include frontmatter with at least `title` and `sidebar_position`.
+- Use Mermaid code blocks for diagrams (theme plugin is configured).
+- Use Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`) for callouts.
+- Links between docs must be relative paths, not absolute URLs.
+- Code examples must be complete and runnable — no pseudo-code in tutorials.
+- Images go in `static/img/` and are referenced as `/img/filename.png`.
+- When adding a new doc page, update the relevant sidebar file (`sidebars.ts` or `sidebarsYellowSdk.ts`).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "npm start*",
+      "npm run build*",
+      "npm run serve*",
+      "npm run typecheck*",
+      "npm run sync:*",
+      "npm run version:*",
+      "npx prettier*",
+      "npx docusaurus*",
+      "git status*",
+      "git log*",
+      "git diff*",
+      "git branch*",
+      "gh pr *",
+      "gh issue *",
+      "gh run *"
+    ],
+    "deny": [
+      "git push --force*",
+      "git reset --hard*",
+      "rm -rf *",
+      "npm publish*"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vercel
+
+# Claude Code local files
+.claude/settings.local.json
+.claude/agent-memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Yellow Network Documentation Site
+
+Docusaurus 3.9.2 documentation site for Yellow Network / Nitrolite protocol.
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `npm start` | Dev server on :3000 |
+| `npm run build` | Production build |
+| `npm run serve` | Serve production build locally |
+| `npm run typecheck` | TypeScript type check |
+| `npm run sync:contracts` | Sync contract docs from nitrolite repo |
+| `npm run version:release` | Create a new versioned snapshot |
+| `npm run version:remove` | Remove a version |
+
+## Site Configuration
+
+- **Config:** `docusaurus.config.ts` — site metadata, plugins, theme config
+- **Sidebars:** `sidebars.ts` (main) + `sidebarsYellowSdk.ts` (SDK section)
+- **Tailwind:** `tailwind.config.js`, `postcss.config.js`
+- **TypeScript:** `tsconfig.json`
+- **URL:** https://docs.yellow.org
+
+## Documentation Structure
+
+| Path | Content |
+|------|---------|
+| `docs/learn/` | Conceptual explainers (architecture, state channels, clearing) |
+| `docs/guides/` | How-to guides (integration, setup) |
+| `docs/tutorials/` | Step-by-step walkthroughs |
+| `docs/api-reference/` | SDK and contract API reference |
+| `docs/protocol/` | Protocol specification |
+| `docs/build/` | Builder guides |
+
+## Versioning
+
+- Versioned docs live in `versioned_docs/` and `versioned_sidebars/`
+- `versions.json` tracks released versions
+- Scripts in `scripts/` manage version lifecycle
+
+## Content Conventions
+
+- Use **MDX** for interactive content, plain **Markdown** for simple pages
+- Always include frontmatter: `title`, `sidebar_position` (minimum)
+- Diagrams: use Mermaid (theme plugin included)
+- Admonitions: `:::note`, `:::tip`, `:::warning`, `:::danger`
+- Code blocks must be complete and runnable
+- Use relative links between docs (not absolute URLs)
+- Images go in `static/img/`
+
+## Search
+
+- Primary: Algolia DocSearch
+- Fallback: Lunr (local, `docusaurus-lunr-search`)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `docusaurus.config.ts` | Site config, plugins, navbar, footer |
+| `sidebars.ts` | Main sidebar structure |
+| `sidebarsYellowSdk.ts` | SDK docs sidebar |
+| `src/pages/` | Custom pages (landing, whitepaper) |
+| `src/css/custom.css` | Global style overrides |
+| `scripts/sync-contracts-docs.js` | Syncs Solidity NatSpec to docs |
+
+## Git
+
+- Default branch: `master`
+- PR target: `master`
+- Commit style: `docs|feat|fix(scope): message`


### PR DESCRIPTION
## Summary

Adds Claude Code configuration for the docs site — conventions, permissions, and rules for AI-assisted documentation editing.

- **`CLAUDE.md`**: Docusaurus site context (commands, structure, content conventions, versioning)
- **`.claude/settings.json`**: Permission allow/deny lists
- **`.claude/rules/docs.md`**: MDX/Markdown conventions (frontmatter, admonitions, Mermaid, relative links)

## Test plan

- [ ] Fresh Claude Code session loads `CLAUDE.md` automatically
- [ ] `npm run build` auto-allowed (no permission prompt)
- [ ] `git push --force` blocked by deny list

