### PR TITLE
YNU-864: Harness rule cleanup

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,3 +6,14 @@ mdx = md
 
 [*.{md,mdx}]
 BasedOnStyles = Yellow
+
+# Quadrant-specific rules. Off by default; per-folder overlays opt in.
+Yellow.NoMetaphor = NO
+Yellow.SpecVoice = NO
+Yellow.NoNarrative = NO
+Yellow.LearnCrossLink = NO
+Yellow.ProtocolCrossLink = NO
+Yellow.BuildPageShapeTLDR = NO
+Yellow.BuildPageShapeStepByStep = NO
+Yellow.BuildPageShapeVerify = NO
+Yellow.BuildPageShapeNextSteps = NO

--- a/.vale/styles/Yellow/AISlop.yml
+++ b/.vale/styles/Yellow/AISlop.yml
@@ -8,7 +8,7 @@ tokens:
   - "\\bdelve\\b"
   - "\\bleverage\\b"
   - "\\bunlock\\b"
-  - "\\bharness(?:es|ed|ing)?\\b"
+  - "\\bharness(?:es|ed|ing)?\\s+(?:the|your|its|our|all|this|these|those|every|any)\\b"
   - "\\bseamlessly\\b"
   - "\\bseamless\\b"
   - "\\brobust\\b"

--- a/.vale/styles/Yellow/BuildPageShape.yml
+++ b/.vale/styles/Yellow/BuildPageShape.yml
@@ -1,6 +1,0 @@
-extends: occurrence
-message: "Build how-to pages should include TL;DR, Step-by-step, Verify, and Next steps headings."
-level: warning
-scope: raw
-token: "(?m)^## (TL;DR|Step-by-step|Verify|Next steps)\\b"
-min: 4

--- a/.vale/styles/Yellow/BuildPageShapeNextSteps.yml
+++ b/.vale/styles/Yellow/BuildPageShapeNextSteps.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Build how-to pages must include a '## Next steps' heading."
+level: error
+scope: raw
+token: "(?m)^## Next steps\\b"
+min: 1

--- a/.vale/styles/Yellow/BuildPageShapeStepByStep.yml
+++ b/.vale/styles/Yellow/BuildPageShapeStepByStep.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Build how-to pages must include a '## Step-by-step' heading."
+level: error
+scope: raw
+token: "(?m)^## Step-by-step\\b"
+min: 1

--- a/.vale/styles/Yellow/BuildPageShapeTLDR.yml
+++ b/.vale/styles/Yellow/BuildPageShapeTLDR.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Build how-to pages must include a '## TL;DR' heading."
+level: error
+scope: raw
+token: "(?m)^## TL;DR\\b"
+min: 1

--- a/.vale/styles/Yellow/BuildPageShapeVerify.yml
+++ b/.vale/styles/Yellow/BuildPageShapeVerify.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Build how-to pages must include a '## Verify' heading."
+level: error
+scope: raw
+token: "(?m)^## Verify\\b"
+min: 1

--- a/.vale/styles/Yellow/CrossLink.yml
+++ b/.vale/styles/Yellow/CrossLink.yml
@@ -1,6 +1,0 @@
-extends: occurrence
-message: "Learn and Protocol pages should declare their counterpart link in frontmatter."
-level: warning
-scope: raw
-token: "(?m)^(protocol_link|learn_link):"
-min: 1

--- a/.vale/styles/Yellow/LearnCrossLink.yml
+++ b/.vale/styles/Yellow/LearnCrossLink.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Learn pages must declare 'protocol_link' in frontmatter to point at their Protocol counterpart."
+level: error
+scope: raw
+token: "(?m)^protocol_link:"
+min: 1

--- a/.vale/styles/Yellow/NeedBasedLabels.yml
+++ b/.vale/styles/Yellow/NeedBasedLabels.yml
@@ -8,4 +8,3 @@ tokens:
   - "\\bnitronode-rpc-overview\\b"
   - "\\bsdk-compat-eventpoller\\b"
   - "\\bapp-sessions-multi-party\\b"
-  - "\\b[a-z0-9]+(?:-[a-z0-9]+){2,}\\b"

--- a/.vale/styles/Yellow/ProtocolCrossLink.yml
+++ b/.vale/styles/Yellow/ProtocolCrossLink.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Protocol pages must declare 'learn_link' in frontmatter to point at their Learn counterpart."
+level: error
+scope: raw
+token: "(?m)^learn_link:"
+min: 1


### PR DESCRIPTION
## Summary

Follow-up to #150 that tightens the docs language harness before it is promoted from advisory to blocking.

## What changed

- Disabled quadrant-specific rules by default in the root Vale config so per-folder overlays opt in explicitly.
- Narrowed the `AISlop` `harness` token to verbal context, so noun usage like "language harness" does not trigger.
- Dropped the broad `NeedBasedLabels` catch-all and kept the explicit internal-label examples.
- Replaced the aggregate `BuildPageShape` rule with four distinct heading-specific error-level rules.
- Added directional `LearnCrossLink` and `ProtocolCrossLink` rules, both disabled by default until overlays activate them.
- Removed the non-directional `CrossLink.yml` rule.

## Context

The original harness skeleton landed in #150. This cleanup follows the language harness PRD at `ynu-864-yellow-docs-v1-review/05-language-harness-prd.md`, especially sections 5, 6, 7, 9, and 11.

## Validation

- Installed and used Vale 3.14.1 locally.
- `vale ls-config 2>&1 | grep -i "BuildPageShape"` shows four distinct rule names: `BuildPageShapeTLDR`, `BuildPageShapeStepByStep`, `BuildPageShapeVerify`, and `BuildPageShapeNextSteps`.
- `vale --minAlertLevel=error templates` returns 0 findings.
- `vale --minAlertLevel=error docs | tail -20` still shows the existing 71 docs findings from #150-era advisory mode; this PR does not change docs content.
- Parsed every Yellow rule file with PyYAML in a temporary venv.
- `npm run build 2>&1 | tail -10` succeeds with the same existing 0.5.x broken-link/anchor warning tail.
- `git diff --check` passes.
- Signed commit verified locally with the repo's 1Password SSH signing key.