### PR TITLE
Enable Builder Toolkit playground links

### DIFF
--- a/docs/nitrolite/builder-toolkit.mdx
+++ b/docs/nitrolite/builder-toolkit.mdx
@@ -28,12 +28,15 @@ Start here when you want to build with Nitrolite before reading every page. Use 
     </div>
   </article>
 
-  <article className="card nitrolite-toolkit-card nitrolite-toolkit-card--disabled">
+  <article className="card nitrolite-toolkit-card">
     <div className="card__body nitrolite-toolkit-card__body">
-      <div className="nitrolite-toolkit-card__badge">Coming soon</div>
+      <div className="nitrolite-toolkit-card__eyebrow">Browser tooling</div>
       <h2>Nitrolite Playground</h2>
-      <p>Manage channels and inspect active app sessions from one UI. App-session management will be available after the playground deployment is ready for builders.</p>
-      <span className="button button--secondary button--sm disabled">Deployment pending</span>
+      <p>Manage channels and inspect active app sessions from one UI. Use production for live Nitronode flows or sandbox when you want a disposable test environment.</p>
+    </div>
+    <div className="card__footer nitrolite-toolkit-card__footer">
+      <a className="button button--primary button--sm" href="https://nitronode.yellow.org/v1/playground/" target="_blank" rel="noopener noreferrer">Production</a>
+      <a className="button button--secondary button--sm" href="https://nitronode-sandbox.yellow.org/v1/playground/" target="_blank" rel="noopener noreferrer">Sandbox</a>
     </div>
   </article>
 
@@ -46,12 +49,14 @@ Start here when you want to build with Nitrolite before reading every page. Use 
     </div>
   </article>
 
-  <article className="card nitrolite-toolkit-card nitrolite-toolkit-card--disabled">
+  <article className="card nitrolite-toolkit-card">
     <div className="card__body nitrolite-toolkit-card__body">
-      <div className="nitrolite-toolkit-card__badge">Coming soon</div>
+      <div className="nitrolite-toolkit-card__eyebrow">Sandbox funding</div>
       <h2>Faucet App</h2>
-      <p>Get testnet assets for the v1 builder flow without leaving the Nitrolite docs path. This will be linked here once the faucet deployment is ready.</p>
-      <span className="button button--secondary button--sm disabled">Deployment pending</span>
+      <p>Use the integrated faucet inside the sandbox playground to drip sandbox YUSD while the standalone Faucet App UI is being designed.</p>
+    </div>
+    <div className="card__footer nitrolite-toolkit-card__footer">
+      <a className="button button--primary button--sm" href="https://nitronode-sandbox.yellow.org/v1/playground/" target="_blank" rel="noopener noreferrer">Open sandbox faucet</a>
     </div>
   </article>
 </div>


### PR DESCRIPTION
## Summary

- Enables the Nitrolite Playground card in Builder Toolkit with production and sandbox links.
- Enables the Faucet App card by pointing builders to the integrated sandbox playground faucet for sandbox YUSD.
- Leaves Yellow SDK MCP greyed out as upcoming.

## Validation

- `vale --minAlertLevel=error docs/nitrolite/builder-toolkit.mdx`
- `git diff --check`
- `npm run build`

<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/ff8573b2-4a25-4825-aa0f-939b5f5091b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Activated Nitrolite Playground in the builder toolkit with direct links to production and sandbox environments.
  * Activated Faucet App with a functional link to the sandbox faucet for test network funding.
  * Updated tool availability status in the documentation to reflect currently accessible developer resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/docs/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->