### PR TITLE
Add v1 supported assets matrix

### DIFF
--- a/docs/nitrolite/build/getting-started/prerequisites.mdx
+++ b/docs/nitrolite/build/getting-started/prerequisites.mdx
@@ -123,14 +123,23 @@ Create `.env` for sensitive values:
 # .env - never commit this file
 USER_PRIVATE_KEY=0x...
 APP_PRIVATE_KEY=0x...
-NITRONODE_WS_URL=<sandbox-url-coming-soon>
+NITRONODE_WS_URL=wss://nitronode-sandbox.yellow.org/v1/ws
 RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 CHAIN_ID=11155111
 ASSET=yellow
 ```
 
-:::info Test endpoint
-`NITRONODE_WS_URL` should point at a v1 Nitronode endpoint for the environment you are testing against. Use the current sandbox or test endpoint provided for your environment until the public sandbox URL is pinned.
+:::info Public Nitronode endpoints
+`NITRONODE_WS_URL` should point at a v1 Nitronode endpoint for the environment you are testing against:
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
+
+Use sandbox for development wallets and faucet-funded test assets. Use production only when you intentionally connect to mainnet assets.
+:::
+
+:::tip Builder Toolkit
+Need a consolidated list of live examples, source repositories, Playground, faucet, MCP, and SDK entry points? Open the [Builder Toolkit](/nitrolite/builder-toolkit).
 :::
 
 Add local files to `.gitignore`:
@@ -248,5 +257,6 @@ Use `withApplicationID(appID)` when you want Nitronode records tagged with the a
 ## Next Steps
 
 - [Quickstart](./quickstart) - run the native v1 channel and app-session lifecycle.
+- [Builder Toolkit](/nitrolite/builder-toolkit) - find live examples, Playground, faucet, MCP, and SDK entry points.
 - [Key Terms & Mental Models](./key-terms) - learn the vocabulary used across the docs.
 - [TypeScript SDK](../sdk/typescript/getting-started) - read the full SDK guide.

--- a/docs/nitrolite/build/getting-started/quickstart.mdx
+++ b/docs/nitrolite/build/getting-started/quickstart.mdx
@@ -23,6 +23,14 @@ You need:
 
 See [Prerequisites & Environment](./prerequisites) for the full setup checklist.
 
+:::tip Public Nitronode endpoints
+Use `wss://nitronode-sandbox.yellow.org/v1/ws` while testing on sandbox assets. Use `wss://nitronode.yellow.org/v1/ws` only when you intentionally connect to production/mainnet assets.
+:::
+
+:::info Builder Toolkit
+Need a consolidated list of live examples, source repositories, Playground, faucet, MCP, and SDK entry points? Open the [Builder Toolkit](/nitrolite/builder-toolkit).
+:::
+
 ## Step 1: Install and configure
 
 Clone the docs repo, enter the tested example package, and install its isolated dependencies:
@@ -39,7 +47,7 @@ Edit `.env`:
 ```bash title=".env"
 USER_PRIVATE_KEY=0x...
 APP_PRIVATE_KEY=0x...
-NITRONODE_WS_URL=<sandbox-url-coming-soon>
+NITRONODE_WS_URL=wss://nitronode-sandbox.yellow.org/v1/ws
 RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 CHAIN_ID=11155111
 ASSET=yellow

--- a/docs/nitrolite/build/sdk/cerebro.mdx
+++ b/docs/nitrolite/build/sdk/cerebro.mdx
@@ -43,13 +43,13 @@ go build -o cerebro ./cerebro
 Start Cerebro with an explicit Nitronode endpoint:
 
 ```bash
-cerebro wss://nitronode.example.com/v1/ws
+cerebro wss://nitronode-sandbox.yellow.org/v1/ws
 ```
 
 If you built from source:
 
 ```bash
-./cerebro wss://nitronode.example.com/v1/ws
+./cerebro wss://nitronode-sandbox.yellow.org/v1/ws
 ```
 
 When no endpoint is passed, Cerebro uses the stored endpoint if one exists. Otherwise it connects to:
@@ -87,8 +87,10 @@ cerebro> config
 Persist a different Nitronode endpoint:
 
 ```text
-cerebro> config node set-ws-url wss://nitronode.example.com/v1/ws
+cerebro> config node set-ws-url wss://nitronode.yellow.org/v1/ws
 ```
+
+Use `wss://nitronode.yellow.org/v1/ws` only when you intentionally connect Cerebro to production/mainnet assets.
 
 ## Quickstart Flow
 

--- a/docs/nitrolite/build/sdk/go/getting-started.mdx
+++ b/docs/nitrolite/build/sdk/go/getting-started.mdx
@@ -23,8 +23,11 @@ go get github.com/layer-3/nitrolite/sdk/go
 
 ## Quick Start
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL in `sdk.NewClient()`. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+Use the sandbox endpoint in `sdk.NewClient()` while testing. Switch to production only when your service intentionally connects to mainnet assets.
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
 :::
 
 ```go
@@ -61,7 +64,7 @@ func main() {
     }
 
     client, err := sdk.NewClient(
-        "<sandbox-url-coming-soon>",
+        "wss://nitronode-sandbox.yellow.org/v1/ws",
         stateSigner,
         txSigner,
         sdk.WithBlockchainRPC(chainID, "https://ethereum-sepolia-rpc.example"),

--- a/docs/nitrolite/build/sdk/multi-party-app-sessions.mdx
+++ b/docs/nitrolite/build/sdk/multi-party-app-sessions.mdx
@@ -31,14 +31,17 @@ You need two disposable wallets, a Nitronode WebSocket URL, a chain RPC URL, and
 ```bash
 USER_1_PRIVATE_KEY=0x...
 USER_2_PRIVATE_KEY=0x...
-NITRONODE_WS_URL=<sandbox-url-coming-soon>
+NITRONODE_WS_URL=wss://nitronode-sandbox.yellow.org/v1/ws
 RPC_URL=https://polygon-amoy.g.alchemy.com/v2/YOUR_KEY
 CHAIN_ID=80002
 ASSET=usdc
 ```
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL for `NITRONODE_WS_URL`. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+Use the sandbox endpoint for disposable wallets and test assets. Use production/mainnet only when you intentionally connect to live assets.
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
 :::
 
 ## Step 1: Connect both participants
@@ -60,7 +63,7 @@ import {
 } from '@yellow-org/sdk';
 import Decimal from 'decimal.js';
 
-const wsURL = process.env.NITRONODE_WS_URL ?? '<sandbox-url-coming-soon>';
+const wsURL = process.env.NITRONODE_WS_URL ?? 'wss://nitronode-sandbox.yellow.org/v1/ws';
 const chainId = BigInt(process.env.CHAIN_ID ?? '80002');
 const asset = process.env.ASSET ?? 'usdc';
 

--- a/docs/nitrolite/build/sdk/typescript-compat/event-poller.mdx
+++ b/docs/nitrolite/build/sdk/typescript-compat/event-poller.mdx
@@ -46,7 +46,7 @@ import {
 } from '@yellow-org/sdk-compat';
 
 const client = await NitroliteClient.create({
-  wsURL: '<sandbox-url-coming-soon>',
+  wsURL: 'wss://nitronode-sandbox.yellow.org/v1/ws',
   walletClient,
   chainId: 11155111,
   blockchainRPCs: blockchainRPCsFromEnv(),
@@ -73,6 +73,8 @@ window.addEventListener('beforeunload', () => {
   poller.stop();
 });
 ```
+
+This example uses the sandbox Nitronode endpoint. Use `wss://nitronode.yellow.org/v1/ws` only when the migrated app is ready for production/mainnet assets.
 
 ## Intervals
 

--- a/docs/nitrolite/build/sdk/typescript-compat/migration-onchain.mdx
+++ b/docs/nitrolite/build/sdk/typescript-compat/migration-onchain.mdx
@@ -99,7 +99,7 @@ If an on-chain helper needs an RPC URL for a chain, pass `blockchainRPCs` when c
 
 ```typescript
 const client = await NitroliteClient.create({
-  wsURL: '<sandbox-url-coming-soon>',
+  wsURL: 'wss://nitronode-sandbox.yellow.org/v1/ws',
   walletClient,
   chainId: 11155111,
   blockchainRPCs: {
@@ -107,6 +107,8 @@ const client = await NitroliteClient.create({
   },
 });
 ```
+
+This example uses the sandbox Nitronode endpoint. Use `wss://nitronode.yellow.org/v1/ws` only when migration code is ready for production/mainnet assets.
 
 ## Approval Helpers
 

--- a/docs/nitrolite/build/sdk/typescript-compat/migration-overview.mdx
+++ b/docs/nitrolite/build/sdk/typescript-compat/migration-overview.mdx
@@ -69,7 +69,7 @@ const parsed = parseGetChannelsResponse(raw);
 import { NitroliteClient, blockchainRPCsFromEnv } from '@yellow-org/sdk-compat';
 
 const client = await NitroliteClient.create({
-  wsURL: '<sandbox-url-coming-soon>',
+  wsURL: 'wss://nitronode-sandbox.yellow.org/v1/ws',
   walletClient,
   chainId: 11155111,
   blockchainRPCs: blockchainRPCsFromEnv(),
@@ -78,8 +78,8 @@ const client = await NitroliteClient.create({
 const channels = await client.getChannels();
 ```
 
-:::info Sandbox URL - coming soon
-Use the same Nitronode URL placeholder pattern as the native v1 quickstart. Replace `<sandbox-url-coming-soon>` only when the canonical sandbox host is pinned.
+:::info Public Nitronode endpoints
+Use `wss://nitronode-sandbox.yellow.org/v1/ws` for migration tests with sandbox assets. Use `wss://nitronode.yellow.org/v1/ws` only when you intentionally connect migrated code to production/mainnet assets.
 :::
 
 ## Migration Matrix

--- a/docs/nitrolite/build/sdk/typescript-compat/overview.mdx
+++ b/docs/nitrolite/build/sdk/typescript-compat/overview.mdx
@@ -53,8 +53,11 @@ npm install @yellow-org/sdk-compat
 npm install @yellow-org/sdk viem
 ```
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL in the `wsURL` field below. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+Use the sandbox endpoint in the `wsURL` field below while testing a migration. Use production/mainnet only when you intentionally connect to live assets.
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
 :::
 
 ## Quick Start
@@ -63,7 +66,7 @@ Use your Nitronode WebSocket URL in the `wsURL` field below. The public sandbox 
 import { NitroliteClient, blockchainRPCsFromEnv } from '@yellow-org/sdk-compat';
 
 const client = await NitroliteClient.create({
-  wsURL: '<sandbox-url-coming-soon>',
+  wsURL: 'wss://nitronode-sandbox.yellow.org/v1/ws',
   walletClient,          // viem WalletClient with account
   chainId: 11155111,     // Sepolia
   blockchainRPCs: blockchainRPCsFromEnv(),

--- a/docs/nitrolite/build/sdk/typescript/configuration.mdx
+++ b/docs/nitrolite/build/sdk/typescript/configuration.mdx
@@ -10,8 +10,11 @@ sidebar_position: 3
 
 Configuration is passed as variadic options to `Client.create()`:
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL for `wsURL`. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+Use the sandbox endpoint for local development and test assets. Use production/mainnet only when your app is ready for live assets.
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
 :::
 
 ```typescript
@@ -24,7 +27,7 @@ import {
 } from '@yellow-org/sdk';
 
 const client = await Client.create(
-  '<sandbox-url-coming-soon>',
+  'wss://nitronode-sandbox.yellow.org/v1/ws',
   stateSigner,
   txSigner,
   withBlockchainRPC(chainId, rpcURL),  // Blockchain RPC (required for checkpoint)
@@ -70,7 +73,7 @@ import Decimal from 'decimal.js';
 const { stateSigner, txSigner } = createSigners(process.env.PRIVATE_KEY as `0x${string}`);
 
 const client = await Client.create(
-  '<sandbox-url-coming-soon>',
+  'wss://nitronode-sandbox.yellow.org/v1/ws',
   stateSigner,
   txSigner,
   withBlockchainRPC(80002n, process.env.POLYGON_AMOY_RPC!),

--- a/docs/nitrolite/build/sdk/typescript/examples.mdx
+++ b/docs/nitrolite/build/sdk/typescript/examples.mdx
@@ -6,8 +6,8 @@ sidebar_position: 4
 
 # Examples
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL in each `Client.create()` call below. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+The examples below use the sandbox endpoint. Use `wss://nitronode.yellow.org/v1/ws` only when you intentionally connect to production/mainnet assets.
 :::
 
 ## Basic Deposit and Transfer
@@ -20,7 +20,7 @@ async function basicExample() {
   const { stateSigner, txSigner } = createSigners(process.env.PRIVATE_KEY as `0x${string}`);
 
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withBlockchainRPC(80002n, process.env.RPC_URL!)
@@ -66,7 +66,7 @@ async function multiChainExample() {
   const { stateSigner, txSigner } = createSigners(process.env.PRIVATE_KEY as `0x${string}`);
 
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withBlockchainRPC(80002n, process.env.POLYGON_RPC!),
@@ -100,7 +100,7 @@ import { Client, createSigners } from '@yellow-org/sdk';
 async function queryTransactions() {
   const { stateSigner, txSigner } = createSigners(process.env.PRIVATE_KEY as `0x${string}`);
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner
   );
@@ -150,7 +150,7 @@ async function appSessionExample() {
   );
 
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withBlockchainRPC(80002n, process.env.RPC_URL!)
@@ -294,7 +294,7 @@ async function connectWithWallet() {
   const txSigner = new BrowserTransactionSigner(walletClient);
 
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withBlockchainRPC(11155111n, 'https://rpc.sepolia.io'),
@@ -451,7 +451,7 @@ async function monitorConnection() {
   const { stateSigner, txSigner } = createSigners(process.env.PRIVATE_KEY as `0x${string}`);
 
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withErrorHandler((error) => {

--- a/docs/nitrolite/build/sdk/typescript/getting-started.mdx
+++ b/docs/nitrolite/build/sdk/typescript/getting-started.mdx
@@ -31,8 +31,11 @@ pnpm add @yellow-org/sdk
 
 ## Quick Start
 
-:::info Sandbox URL - coming soon
-Use your Nitronode WebSocket URL in the `Client.create()` call below. The public sandbox URL is intentionally shown as `<sandbox-url-coming-soon>` until the canonical host is pinned.
+:::info Public Nitronode endpoints
+Use the sandbox endpoint in the `Client.create()` call below while testing. Switch to production only when your app intentionally connects to mainnet assets.
+
+- Sandbox: `wss://nitronode-sandbox.yellow.org/v1/ws`
+- Production/mainnet: `wss://nitronode.yellow.org/v1/ws`
 :::
 
 ```typescript
@@ -47,7 +50,7 @@ async function main() {
 
   // 2. Create unified client
   const client = await Client.create(
-    '<sandbox-url-coming-soon>',
+    'wss://nitronode-sandbox.yellow.org/v1/ws',
     stateSigner,
     txSigner,
     withBlockchainRPC(80002n, 'https://polygon-amoy.alchemy.com/v2/KEY')

--- a/docs/nitrolite/learn/index.mdx
+++ b/docs/nitrolite/learn/index.mdx
@@ -55,6 +55,7 @@ The v1 protocol uses ChannelHub, Nitronode, channel states, home ledgers, and ap
 After completing the Learn section, continue to:
 
 - **[Build](/nitrolite/build/getting-started/quickstart)**: Implement complete Yellow applications.
+- **[Builder Toolkit](/nitrolite/builder-toolkit)**: Find a consolidated list of live examples, source repositories, Playground, faucet, MCP, and SDK entry points.
 - **[Protocol](/nitrolite/protocol/introduction)**: Read the authoritative protocol specification.
 - **[Yellow SDK MCP](/nitrolite/build/sdk/mcp)**: Connect Yellow SDK to your AI coding tool so you can ask guided questions while you learn and build.
 

--- a/docs/nitrolite/learn/introduction/supported-chains.mdx
+++ b/docs/nitrolite/learn/introduction/supported-chains.mdx
@@ -68,14 +68,16 @@ The table below was queried from the public v1 Nitronode endpoints on June 2, 20
 
 ## Current Asset Matrix
 
+Use this matrix for asset availability. Exact token decimals can vary by chain, so use the token address tables below when configuring amounts.
+
 | Asset symbol | Sandbox Nitronode | Production Nitronode |
 | --- | --- | --- |
 | `eth` | Ether, 18 decimals. Available on Linea Sepolia `59141`, Base Sepolia `84532`, and Ethereum Sepolia `11155111`. | Ether, 18 decimals. Available on Linea `59144`. |
 | `pol` | POL, 18 decimals. Available on Polygon Amoy `80002`. | Not listed. |
-| `usdt` | Not listed. | Tether USD, 6 unified decimals. Available on Ethereum `1`, Flare `14`, BSC `56`, Polygon `137`, Base `8453`, Linea `59144`, and XRPL EVM `1440000`. |
-| `xrp` | XRP, 18 unified decimals. Available on XRPL EVM Testnet `1449000`. | XRP, 6 unified decimals. Available on Flare `14` and XRPL EVM `1440000`. |
+| `usdt` | Not listed. | Tether USD. Available on Ethereum `1`, Flare `14`, BSC `56`, Polygon `137`, Base `8453`, Linea `59144`, and XRPL EVM `1440000`; token decimals are chain-specific. |
+| `xrp` | XRP. Available on XRPL EVM Testnet `1449000`; token decimals are chain-specific. | XRP. Available on Flare `14` and XRPL EVM `1440000`; token decimals are chain-specific. |
 | `yellow` | Yellow, 18 decimals. Available on Ethereum Sepolia `11155111`. | Yellow, 18 decimals. Available on Ethereum `1`. |
-| `yusd` | Yellow USD, 6 unified decimals. Available on Linea Sepolia `59141`, Polygon Amoy `80002`, Base Sepolia `84532`, XRPL EVM Testnet `1449000`, and Ethereum Sepolia `11155111`. | Not listed. |
+| `yusd` | Yellow USD. Available on Linea Sepolia `59141`, Polygon Amoy `80002`, Base Sepolia `84532`, XRPL EVM Testnet `1449000`, and Ethereum Sepolia `11155111`; token decimals are chain-specific. | Not listed. |
 
 ## Production Token Addresses
 

--- a/docs/nitrolite/learn/introduction/supported-chains.mdx
+++ b/docs/nitrolite/learn/introduction/supported-chains.mdx
@@ -51,6 +51,10 @@ for (const asset of assets) {
 
 Raw RPC clients can call `node.v1.get_config` for blockchain and ChannelHub data and `node.v1.get_assets` for asset and token data.
 
+:::tip Builder Toolkit
+Need a consolidated list of live examples, source repositories, Playground, faucet, MCP, and SDK entry points? Open the [Builder Toolkit](/nitrolite/builder-toolkit).
+:::
+
 ---
 
 ## Current Public Endpoints
@@ -132,5 +136,6 @@ Asset symbols are node configuration, not protocol constants. The current v1 san
 ## See Also
 
 - [Quick Start Guide](/nitrolite/build/getting-started/quickstart) — Get started building with Yellow SDK
+- [Builder Toolkit](/nitrolite/builder-toolkit) — Find live examples, Playground, faucet, MCP, and SDK entry points
 - [Multi-Party App Sessions](/nitrolite/build/sdk/multi-party-app-sessions) — Create multi-party application sessions
 - [API Reference](/nitrolite/api-reference) — Complete SDK documentation

--- a/docs/nitrolite/learn/introduction/supported-chains.mdx
+++ b/docs/nitrolite/learn/introduction/supported-chains.mdx
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 3
 title: Supported Chains & Assets
-description: Discover supported blockchains, assets, and ChannelHub addresses at runtime
-keywords: [supported chains, blockchains, assets, tokens, ChannelHub, Ethereum Sepolia, Polygon Amoy, Base Sepolia]
+description: Discover supported blockchains, assets, tokens, and ChannelHub addresses at runtime
+keywords: [supported chains, supported assets, blockchains, assets, tokens, ChannelHub, USDT, YUSD, YELLOW]
 ---
 
 # Supported Chains & Assets
@@ -50,6 +50,62 @@ for (const asset of assets) {
 ```
 
 Raw RPC clients can call `node.v1.get_config` for blockchain and ChannelHub data and `node.v1.get_assets` for asset and token data.
+
+---
+
+## Current Public Endpoints
+
+The table below was queried from the public v1 Nitronode endpoints on June 2, 2026. Treat it as a convenience snapshot. The active endpoint response from `node.v1.get_assets` remains the source of truth for production code.
+
+| Environment | WebSocket endpoint | Node address | Node version |
+| --- | --- | --- | --- |
+| Production (mainnet) | `wss://nitronode.yellow.org/v1/ws` | `0xbffaa37e34fb9aa11b23eb6cc939abbb45d6ccb6` | `55fd346` |
+| Sandbox | `wss://nitronode-sandbox.yellow.org/v1/ws` | `0x6f375dad1ff0ad968bdde939f76a2b3d6b9d3ec5` | `55fd346` |
+
+## Current Asset Matrix
+
+| Asset symbol | Sandbox Nitronode | Production Nitronode |
+| --- | --- | --- |
+| `eth` | Ether, 18 decimals. Available on Linea Sepolia `59141`, Base Sepolia `84532`, and Ethereum Sepolia `11155111`. | Ether, 18 decimals. Available on Linea `59144`. |
+| `pol` | POL, 18 decimals. Available on Polygon Amoy `80002`. | Not listed. |
+| `usdt` | Not listed. | Tether USD, 6 unified decimals. Available on Ethereum `1`, Flare `14`, BSC `56`, Polygon `137`, Base `8453`, Linea `59144`, and XRPL EVM `1440000`. |
+| `xrp` | XRP, 18 unified decimals. Available on XRPL EVM Testnet `1449000`. | XRP, 6 unified decimals. Available on Flare `14` and XRPL EVM `1440000`. |
+| `yellow` | Yellow, 18 decimals. Available on Ethereum Sepolia `11155111`. | Yellow, 18 decimals. Available on Ethereum `1`. |
+| `yusd` | Yellow USD, 6 unified decimals. Available on Linea Sepolia `59141`, Polygon Amoy `80002`, Base Sepolia `84532`, XRPL EVM Testnet `1449000`, and Ethereum Sepolia `11155111`. | Not listed. |
+
+## Production Token Addresses
+
+| Asset | Chain | Token address | Token decimals |
+| --- | --- | --- | ---: |
+| `eth` | Linea `59144` | `0x0000000000000000000000000000000000000000` | 18 |
+| `usdt` | Ethereum `1` | `0xdac17f958d2ee523a2206206994597c13d831ec7` | 6 |
+| `usdt` | Flare `14` | `0xe7cd86e13ac4309349f30b3435a9d337750fc82d` | 6 |
+| `usdt` | BSC `56` | `0x55d398326f99059ff775485246999027b3197955` | 18 |
+| `usdt` | Polygon `137` | `0xc2132d05d31c914a87c6611c10748aeb04b58e8f` | 6 |
+| `usdt` | Base `8453` | `0xfde4c96c8593536e31f229ea8f37b2ada2699bb2` | 6 |
+| `usdt` | Linea `59144` | `0xa219439258ca9da29e9cc4ce5596924745e12b93` | 6 |
+| `usdt` | XRPL EVM `1440000` | `0x9f8cf9c00fac501b3965872f4ed3271f6f4d06ff` | 6 |
+| `xrp` | Flare `14` | `0xad552a648c74d49e10027ab8a618a3ad4901c5be` | 6 |
+| `xrp` | XRPL EVM `1440000` | `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` | 18 |
+| `yellow` | Ethereum `1` | `0x236eb848c95b231299b4aa9f56c73d6893462720` | 18 |
+
+## Sandbox Token Addresses
+
+| Asset | Chain | Token address | Token decimals |
+| --- | --- | --- | ---: |
+| `eth` | Linea Sepolia `59141` | `0x0000000000000000000000000000000000000000` | 18 |
+| `eth` | Base Sepolia `84532` | `0x0000000000000000000000000000000000000000` | 18 |
+| `eth` | Ethereum Sepolia `11155111` | `0x0000000000000000000000000000000000000000` | 18 |
+| `pol` | Polygon Amoy `80002` | `0x0000000000000000000000000000000000000000` | 18 |
+| `xrp` | XRPL EVM Testnet `1449000` | `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` | 18 |
+| `yellow` | Ethereum Sepolia `11155111` | `0x236eb848c95b231299b4aa9f56c73d6893462720` | 18 |
+| `yusd` | Linea Sepolia `59141` | `0x67a5f0b0553e22689a539b80cbe4a1cd126e2bde` | 18 |
+| `yusd` | Polygon Amoy `80002` | `0x1b66e510b845a746334b866b62c64746bebff857` | 8 |
+| `yusd` | Base Sepolia `84532` | `0x67a5f0b0553e22689a539b80cbe4a1cd126e2bde` | 6 |
+| `yusd` | XRPL EVM Testnet `1449000` | `0x67a5f0b0553e22689a539b80cbe4a1cd126e2bde` | 18 |
+| `yusd` | Ethereum Sepolia `11155111` | `0x67a5f0b0553e22689a539b80cbe4a1cd126e2bde` | 6 |
+
+Native assets use the sentinel token address returned by Nitronode: `0x0000000000000000000000000000000000000000` for native EVM gas tokens and `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` where the node config uses that native-token marker.
 
 ---
 

--- a/examples/nitrolite-v1-lifecycle/.env.example
+++ b/examples/nitrolite-v1-lifecycle/.env.example
@@ -3,8 +3,8 @@ USER_PRIVATE_KEY=0x...
 APP_PRIVATE_KEY=0x...
 
 # Native v1 Nitronode and matching chain RPC.
-# TODO: Replace with the canonical sandbox URL once it is live.
-NITRONODE_WS_URL=<sandbox-url-coming-soon>
+# Production/mainnet endpoint: wss://nitronode.yellow.org/v1/ws
+NITRONODE_WS_URL=wss://nitronode-sandbox.yellow.org/v1/ws
 RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 CHAIN_ID=11155111
 ASSET=yellow

--- a/examples/nitrolite-v1-lifecycle/README.md
+++ b/examples/nitrolite-v1-lifecycle/README.md
@@ -22,7 +22,7 @@ npm run lifecycle
 
 Use disposable test wallets only. The app signer can be an unfunded test wallet; the user wallet needs Sepolia gas and the selected test asset.
 
-Set `NITRONODE_WS_URL` to the current v1 sandbox or test endpoint provided for your environment before running `npm run lifecycle`.
+Set `NITRONODE_WS_URL` to `wss://nitronode-sandbox.yellow.org/v1/ws` before running `npm run lifecycle`. Use `wss://nitronode.yellow.org/v1/ws` only when the example is ready for production/mainnet assets.
 
 The script calls `enableNodeLocalAccountTransactions()` after creating each SDK client. This keeps viem's local account attached to `writeContract()` requests in Node.js so `approveToken()` and `checkpoint()` can send transactions through public RPC endpoints. Browser wallet apps do not need this shim.
 


### PR DESCRIPTION
## Summary

- Adds a dated v1 supported assets matrix to `Supported Chains & Assets`.
- Lists the current production and sandbox Nitronode endpoints, node addresses, and node version returned by live RPC.
- Adds production and sandbox token address tables for the assets returned by `node.v1.get_assets`.
- Replaces old v1 sandbox placeholders and fake Nitronode hosts with the live sandbox endpoint: `wss://nitronode-sandbox.yellow.org/v1/ws`.
- Adds production endpoint context where builders choose an environment: `wss://nitronode.yellow.org/v1/ws`.
- Adds Builder Toolkit links/callouts from Learn and Build setup pages for the consolidated examples, Playground, faucet, MCP, and SDK entry points.

## Source

Queried on June 2, 2026 using live v1 RPC:

- `wss://nitronode.yellow.org/v1/ws`: `node.v1.get_config`, `node.v1.get_assets`
- `wss://nitronode-sandbox.yellow.org/v1/ws`: `node.v1.get_config`, `node.v1.get_assets`

The page still tells builders to treat runtime discovery as the source of truth for application code.

## Validation

- `rg -n "<sandbox-url-coming-soon>|Sandbox URL - coming soon|canonical host is pinned|nitronode\\.example\\.com|public sandbox URL|current sandbox or test endpoint|TODO: Replace with the canonical sandbox URL" . -g '*.md' -g '*.mdx' -g '*.ts' -g '*.tsx' -g '*.json' -g '*.example'`
- `vale --minAlertLevel=error docs/nitrolite/build/getting-started/quickstart.mdx docs/nitrolite/build/getting-started/prerequisites.mdx docs/nitrolite/build/sdk/typescript/getting-started.mdx docs/nitrolite/build/sdk/typescript/configuration.mdx docs/nitrolite/build/sdk/typescript/examples.mdx docs/nitrolite/build/sdk/go/getting-started.mdx docs/nitrolite/build/sdk/multi-party-app-sessions.mdx docs/nitrolite/build/sdk/typescript-compat/overview.mdx docs/nitrolite/build/sdk/typescript-compat/migration-overview.mdx docs/nitrolite/build/sdk/typescript-compat/migration-onchain.mdx docs/nitrolite/build/sdk/typescript-compat/event-poller.mdx docs/nitrolite/build/sdk/cerebro.mdx docs/nitrolite/learn/index.mdx docs/nitrolite/learn/introduction/supported-chains.mdx examples/nitrolite-v1-lifecycle/README.md`
- `git diff --check`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the Supported Chains & Assets documentation page with improved descriptions, keyword optimization, and current endpoint information to enhance searchability and provide better user reference.
* Added comprehensive reference tables detailing node details, supported assets with decimal specifications, token address mappings, and WebSocket endpoints available for both production and sandbox environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
